### PR TITLE
テストを直す（increment Count）

### DIFF
--- a/src/Counter.vue
+++ b/src/Counter.vue
@@ -1,4 +1,3 @@
-
 <template>
   <div>
     {{ count }}
@@ -8,14 +7,12 @@
 
 <script>
 export default {
-  // name: 'Counter',
-
+  name: 'Counter',
   data() {
     return {
       count: 0
     }
   },
-
   methods: {
     increment() {
       this.count++

--- a/test/Counter.spec.js
+++ b/test/Counter.spec.js
@@ -8,10 +8,11 @@ describe('init', () => {
   })
 })
 
-// describe('Counter.vue', () => {
-//   it('counter test', () => {
-//     const wrapper = shallowMount(Counter);
-//     wrapper.find('button').trigger('click');
-//     expect(wrapper.find('p#js-count').text()).toMatch('1');
-//   })
-// })
+describe('Counter.vue', () => {
+  it('increments count when button is clicked', async () => {
+    const wrapper = shallowMount(Counter);
+    await wrapper.find('button').trigger('click');
+
+    await expect(wrapper.find('div').text()).toMatch('1');
+  })
+})


### PR DESCRIPTION
## やったこと

`wrapper.find('button').trigger('click');` を拾う前にexpect評価をしてテストがコケてたようなので、async/await入れて直した

- before

```
...
 FAIL  test/Counter.spec.js (9.817 s)
  ● Counter.vue › increments count when button is clicked

    expect(received).toMatch(expected)

    Expected substring: "1"
    Received string:    "0
       Increment"

      15 |
    > 16 |     expect(wrapper.find('div').text()).toMatch('1');
         |                                              ^
      17 |   })
      18 | })
      19 |
```

- after

```
...
 PASS  test/Counter.spec.js (10.543 s)

Test Suites: 2 passed, 2 total
Tests:       3 passed, 3 total
```