### PR TITLE
dependabot対応（ssri）

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2714,7 +2714,6 @@ cacache@^12.0.2, cacache@^12.0.3:
     move-concurrently "^1.0.1"
     promise-inflight "^1.0.1"
     rimraf "^2.6.3"
-    ssri "^6.0.1"
     unique-filename "^1.1.1"
     y18n "^4.0.0"
 
@@ -8962,13 +8961,6 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
-
-ssri@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5"
-  integrity sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==
-  dependencies:
-    figgy-pudding "^3.5.1"
 
 ssri@^7.0.0, ssri@^7.1.0:
   version "7.1.0"


### PR DESCRIPTION
https://github.com/miolab/vue_container/security/dependabot/yarn.lock/ssri/open