### PR TITLE
computed, watch 適用

### DIFF
--- a/src/Counter.vue
+++ b/src/Counter.vue
@@ -4,6 +4,9 @@
       <p>例（@click）
         <span class="count-int">{{ count }}</span>
       </p>
+      <p>
+        {{ showOverNumOrLess }}
+      </p>
       <button class="btn-increment" @click="increment">
         oshitara-kazuga-fuemasu
       </button>
@@ -60,6 +63,14 @@ export default {
     },
     removeDescription() {
       this.isMouseover = false
+    }
+  },
+  computed: {
+    showOverNumOrLess: function() {
+      const num = 3;
+      return this.count > num ?
+        String(num) + 'より大きい':
+        String(num) + 'より小さい'
     }
   }
 }

--- a/src/Counter.vue
+++ b/src/Counter.vue
@@ -5,7 +5,7 @@
         <span class="count-int">{{ count }}</span>
         <span class="flash-message-new">{{ flashMessageUpdate }}</span>
       </p>
-      <p>
+      <p :class="fontOrangeStraight">
         {{ showOverNumOrLess }}
       </p>
       <button class="btn-increment" @click="increment">
@@ -46,20 +46,23 @@ export default {
       count: 0,
       flashMessageUpdate: '',
       number: 0,
+      isActiveFontOrangeStraight: false,
       isMouseover: false,
     }
   },
   methods: {
     increment() {
       this.count++
+      this.isActiveFontOrangeStraight = true;
       this.flashMessageUpdate = ' update!';
     },
     countUp: function(times) {
       this.number += 1 * times
     },
-    resetCount: function() {
-      this.number = 0
-      this.count = 0
+    resetCount: async function() {
+      this.number = 0;
+      this.count = 0;
+      this.isActiveFontOrangeStraight = false;
     },
     showDescription() {
       this.isMouseover = true
@@ -74,6 +77,12 @@ export default {
       return this.count > num ?
         String(num) + 'より大きい':
         String(num) + 'より小さい'
+    },
+    fontOrangeStraight: function() {
+      return {
+        'font-orange': this.isActiveFontOrangeStraight,
+        'font-straight': !this.isActiveFontOrangeStraight
+      }
     }
   },
   watch: {
@@ -90,5 +99,11 @@ export default {
 .flash-message-new {
   color: red;
   font-weight: bold;
+}
+.font-orange {
+  color: orange;
+}
+.font-straight {
+  font-style: italic;
 }
 </style>

--- a/src/Counter.vue
+++ b/src/Counter.vue
@@ -3,6 +3,7 @@
     <div>
       <p>例（@click）
         <span class="count-int">{{ count }}</span>
+        <span class="flash-message-new">{{ flashMessageUpdate }}</span>
       </p>
       <p>
         {{ showOverNumOrLess }}
@@ -43,6 +44,7 @@ export default {
   data() {
     return {
       count: 0,
+      flashMessageUpdate: '',
       number: 0,
       isMouseover: false,
     }
@@ -50,6 +52,7 @@ export default {
   methods: {
     increment() {
       this.count++
+      this.flashMessageUpdate = ' update!';
     },
     countUp: function(times) {
       this.number += 1 * times
@@ -72,6 +75,20 @@ export default {
         String(num) + 'より大きい':
         String(num) + 'より小さい'
     }
+  },
+  watch: {
+    count: function() {
+      setTimeout(() => {
+        this.flashMessageUpdate = ''
+      }, 2000)
+    }
   }
 }
 </script>
+
+<style scoped>
+.flash-message-new {
+  color: red;
+  font-weight: bold;
+}
+</style>


### PR DESCRIPTION
- 算出プロパティ
- ウォッチャ

のチートメモ的に。

---

### やったこと

- countの数値大小メッセージを動的に変更させる処理を実装
  - フォントスタイル
  - メッセージ `...より小さい|大きい` 切り替え
- 加算ボタンを押してcountの数値が変わったことをトリガーとして、一定秒数フラッシュメッセージを表示
  - count だけ見て走らせる処理なので、こちらはウォッチャで実装

### イメージ

  |デフォルト|ボタンクリック時|
  |:--|:--|
  |<img width="265" alt="スクリーンショット 2021-05-13 20 27 14" src="https://user-images.githubusercontent.com/33124627/118119837-f3b02c00-b429-11eb-8669-2cd4b295b57e.png">|<img width="251" alt="スクリーンショット 2021-05-13 20 28 03" src="https://user-images.githubusercontent.com/33124627/118119845-f579ef80-b429-11eb-90ee-531a085b0582.png">|
  | |・updateは一定時間のみ表示<br>・オレンジ文字はresetクリックするまで維持|

