### PR TITLE
バリデーション付きフォーム実装（v-model / input text）

### DIFF
--- a/src/components/Forms.vue
+++ b/src/components/Forms.vue
@@ -1,5 +1,6 @@
 <template>
   <div id="forms">
+    <p>フォーム</p>
     <input
       class="input-text"
       type="text"
@@ -7,6 +8,16 @@
     >
     <p>入力結果:
       <span class="show-input-text">{{ message }}</span>
+    </p>
+    <p>バリデーション付きフォーム（v-model.Lazy）</p>
+    <input
+      type="text"
+      v-model.lazy="messageByLazy"
+    >
+    <span>（{{ maxTextLimit }}文字以内）</span>
+    <p>入力結果:
+      <span class="show-input-text">{{ messageByLazy }}</span>
+      <span style="color: red;"> {{ messageLimitAlert }}</span>
     </p>
   </div>
 </template>
@@ -16,7 +27,16 @@ export default {
   name: 'Forms',
   data() {
     return {
-      message: ''
+      message: '',
+      messageByLazy: '',
+      maxTextLimit: 8
+    }
+  },
+  computed: {
+    messageLimitAlert() {
+      return this.messageByLazy.length >= this.maxTextLimit ?
+        String(this.maxTextLimit) + '文字未満にしてください' :
+        ''
     }
   }
 }

--- a/src/components/Forms.vue
+++ b/src/components/Forms.vue
@@ -12,7 +12,7 @@
     <p>バリデーション付きフォーム（v-model.Lazy）</p>
     <input
       type="text"
-      v-model.lazy="messageByLazy"
+      v-model.trim.lazy="messageByLazy"
     >
     <span>（{{ maxTextLimit }}文字以内）</span>
     <p>入力結果:

--- a/src/components/Forms.vue
+++ b/src/components/Forms.vue
@@ -34,8 +34,8 @@ export default {
   },
   computed: {
     messageLimitAlert() {
-      return this.messageByLazy.length >= this.maxTextLimit ?
-        String(this.maxTextLimit) + '文字未満にしてください' :
+      return this.messageByLazy.length > this.maxTextLimit ?
+        String(this.maxTextLimit) + '文字以内にしてください' :
         ''
     }
   }


### PR DESCRIPTION
### やったこと

表題について実装

- v-model.trim.lazy
- computed

--- 

<img width="381" alt="スクリーンショット 2021-05-28 9 31 43" src="https://user-images.githubusercontent.com/33124627/119912973-8e1a7e80-bf97-11eb-996e-e29a57b806a2.png">

---

refs: https://github.com/miolab/vue_container/pull/35